### PR TITLE
feat: add streaming response to summarize bookmarklet

### DIFF
--- a/bookmarklets/summarize.js
+++ b/bookmarklets/summarize.js
@@ -1,19 +1,63 @@
 javascript:(async function () {
-    /* 1. Create and show Spinner */
-    const loader = document.createElement('div');
-    loader.id = 'bm-loader';
-    loader.innerHTML = `
-    <div style="position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);z-index:999999;display:flex;flex-direction:column;align-items:center;justify-content:center;color:white;font-family:sans-serif;">
-      <div style="width:50px;height:50px;border:5px solid #f3f3f3;border-top:5px solid #3498db;border-radius:50%;animation:spin 1s linear infinite;"></div>
-      <p style="margin-top:15px;font-weight:bold;">Bonsai is thinking...</p>
-      <style>@keyframes spin{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}</style>
-    </div>`;
-    document.body.appendChild(loader);
-
     const article = document.querySelector('article') || document.querySelector('[role="main"]') || document.body;
     const articleText = article.innerText || article.textContent;
 
+    /* 1. Open output window immediately with streaming container */
+    const html = `
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <title>Summarized Content</title>
+        <meta charset="UTF-8">
+        <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"><\/script>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.2.0/github-markdown.min.css">
+        <style>
+          body { box-sizing: border-box; min-width: 200px; max-width: 980px; margin: 0 auto; padding: 45px; }
+          @media (max-width: 767px) { body { padding: 15px; } }
+          #streaming-cursor { display: inline-block; width: 8px; height: 1em; background: #3498db; animation: blink 0.7s infinite; vertical-align: text-bottom; margin-left: 2px; }
+          @keyframes blink { 0%,100% { opacity: 1; } 50% { opacity: 0; } }
+        </style>
+      </head>
+      <body class="markdown-body">
+        <div id="content"></div>
+        <span id="streaming-cursor"></span>
+        <script>
+          window.appendText = function(text) {
+            var el = document.getElementById('content');
+            el.textContent += text;
+          };
+          window.finalRender = function() {
+            var el = document.getElementById('content');
+            var raw = el.textContent;
+            el.innerHTML = marked.parse(raw);
+            var cursor = document.getElementById('streaming-cursor');
+            if (cursor) cursor.remove();
+          };
+        <\/script>
+      </body>
+      </html>
+    `;
+
+    const blob = new Blob([html], {type: 'text/html'});
+    const outputWin = window.open(URL.createObjectURL(blob), '_blank');
+
+    if (!outputWin) {
+        alert('Popup blocked. Please allow popups for this site.');
+        return;
+    }
+
+    /* Wait for the output window to load */
+    await new Promise(resolve => {
+        const check = setInterval(() => {
+            if (outputWin.document && outputWin.document.readyState === 'complete') {
+                clearInterval(check);
+                resolve();
+            }
+        }, 50);
+    });
+
     try {
+        /* 2. Send streaming request */
         const response = await fetch('http://localhost:13305/v1/responses', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
@@ -21,47 +65,55 @@ javascript:(async function () {
             body: JSON.stringify({
                 model: "Bonsai-1.7B-gguf",
                 input: "Please summarize the text using precise and concise language. Use headers and bulleted lists in the summary, to make it scannable. Maintain the meaning and factual accuracy. " + articleText,
-                stream: false
+                stream: true
             })
         });
 
         if (!response.ok) throw new Error('API request failed');
 
-        const data = await response.json();
-        const resultMarkdown = data.output[0].content[0].text;
+        /* 3. Read SSE stream and append text deltas */
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
 
-        /* 2. Build HTML with Markdown Parser (Marked.js) */
-        const html = `
-      <!DOCTYPE html>
-      <html>
-      <head>
-        <title>Summarized Content</title>
-        <meta charset="UTF-8">
-        <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.2.0/github-markdown.min.css">
-        <style>
-          body { box-sizing: border-box; min-width: 200px; max-width: 980px; margin: 0 auto; padding: 45px; }
-          @media (max-width: 767px) { body { padding: 15px; } }
-        </style>
-      </head>
-      <body class="markdown-body">
-        <div id="content"></div>
-        <script>
-          /* Inject the markdown into the container */
-          document.getElementById('content').innerHTML = marked.parse(\`${resultMarkdown.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\${/g, '\\${')}\`);
-        </script>
-      </body>
-      </html>
-    `;
+        while (true) {
+            const {done, value} = await reader.read();
+            if (done) break;
 
-        const blob = new Blob([html], {type: 'text/html'});
-        window.open(URL.createObjectURL(blob), '_blank');
+            buffer += decoder.decode(value, {stream: true});
+            const lines = buffer.split('\n');
+            buffer = lines.pop();
+
+            for (const line of lines) {
+                if (!line.startsWith('data: ')) continue;
+                const data = line.slice(6).trim();
+                if (data === '[DONE]') continue;
+
+                try {
+                    const event = JSON.parse(data);
+                    if (event.type === 'response.output_text.delta' && event.delta) {
+                        if (outputWin && !outputWin.closed && outputWin.appendText) {
+                            outputWin.appendText(event.delta);
+                        }
+                    }
+                } catch (e) {
+                    /* skip unparseable lines */
+                }
+            }
+        }
+
+        /* 4. Final markdown render */
+        if (outputWin && !outputWin.closed && outputWin.finalRender) {
+            outputWin.finalRender();
+        }
 
     } catch (err) {
-        alert('Error: ' + err.message);
-    } finally {
-        /* 3. Remove Spinner */
-        const el = document.getElementById('bm-loader');
-        if (el) el.remove();
+        if (outputWin && !outputWin.closed) {
+            outputWin.document.getElementById('content').textContent = 'Error: ' + err.message;
+            var cursor = outputWin.document.getElementById('streaming-cursor');
+            if (cursor) cursor.remove();
+        } else {
+            alert('Error: ' + err.message);
+        }
     }
 })();

--- a/bookmarklets/summarize.js
+++ b/bookmarklets/summarize.js
@@ -22,14 +22,13 @@ javascript:(async function () {
         <div id="content"></div>
         <span id="streaming-cursor"></span>
         <script>
+          var rawText = '';
           window.appendText = function(text) {
+            rawText += text;
             var el = document.getElementById('content');
-            el.textContent += text;
+            el.innerHTML = marked.parse(rawText);
           };
-          window.finalRender = function() {
-            var el = document.getElementById('content');
-            var raw = el.textContent;
-            el.innerHTML = marked.parse(raw);
+          window.streamDone = function() {
             var cursor = document.getElementById('streaming-cursor');
             if (cursor) cursor.remove();
           };
@@ -102,9 +101,9 @@ javascript:(async function () {
             }
         }
 
-        /* 4. Final markdown render */
-        if (outputWin && !outputWin.closed && outputWin.finalRender) {
-            outputWin.finalRender();
+        /* 4. Remove cursor when streaming is complete */
+        if (outputWin && !outputWin.closed && outputWin.streamDone) {
+            outputWin.streamDone();
         }
 
     } catch (err) {


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @kahnwong :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Modifies `bookmarklets/summarize.js` to use streaming responses from the OpenAI-compatible endpoint, rendering text progressively as it's generated.

## Changes

- Set `stream: true` in the API request body
- Open the output window immediately instead of waiting for the full response behind a spinner
- Parse the SSE stream (`response.output_text.delta` events) and append text chunks to the output in real-time
- Added a blinking cursor indicator while streaming is in progress
- Final markdown render (via marked.js + github-markdown-css) happens once the stream completes
- Error handling displays in the output window if open, or falls back to `alert()` if the popup was blocked

## Behavior

1. User clicks the bookmarklet
2. A new tab opens immediately showing text appearing character-by-character as the model generates it
3. Once generation is complete, the raw text is re-rendered as formatted markdown with headers and bullet lists