### PR TITLE
feat: send notification when streaming summary completes

### DIFF
--- a/bookmarklets/summarize.js
+++ b/bookmarklets/summarize.js
@@ -1,8 +1,13 @@
 javascript:(async function () {
+    /* 1. Request notification permission early */
+    if (typeof Notification !== 'undefined' && Notification.permission === 'default') {
+        Notification.requestPermission();
+    }
+
     const article = document.querySelector('article') || document.querySelector('[role="main"]') || document.body;
     const articleText = article.innerText || article.textContent;
 
-    /* 1. Open output window immediately with streaming container */
+    /* 2. Open output window immediately with streaming container */
     const html = `
       <!DOCTYPE html>
       <html>
@@ -56,7 +61,7 @@ javascript:(async function () {
     });
 
     try {
-        /* 2. Send streaming request */
+        /* 3. Send streaming request */
         const response = await fetch('http://localhost:13305/v1/responses', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
@@ -70,7 +75,7 @@ javascript:(async function () {
 
         if (!response.ok) throw new Error('API request failed');
 
-        /* 3. Read SSE stream and append text deltas */
+        /* 4. Read SSE stream and append text deltas */
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
         let buffer = '';
@@ -101,9 +106,14 @@ javascript:(async function () {
             }
         }
 
-        /* 4. Remove cursor when streaming is complete */
+        /* 5. Remove cursor when streaming is complete */
         if (outputWin && !outputWin.closed && outputWin.streamDone) {
             outputWin.streamDone();
+        }
+
+        /* 6. Send browser notification */
+        if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
+            new Notification('Summary Ready', { body: 'Your summary has been generated.' });
         }
 
     } catch (err) {


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @kahnwong :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Adds a browser notification when the streaming summarization response is completed.

## Changes

- Requests `Notification.requestPermission()` early at bookmarklet invocation if not already granted
- After the SSE stream finishes and the cursor is removed, fires a `Notification('Summary Ready', { body: 'Your summary has been generated.' })` so the user knows the summary is ready even if they've switched tabs
- Based on the merged streaming implementation from PR #2 (no merge conflicts)

## Notes

- Supersedes PR #3 which had a merge conflict with the merged PR #2
- The notification only fires if the user has granted permission